### PR TITLE
EDGFQM-1 trigger Workflow api-doc

### DIFF
--- a/src/main/resources/swagger.api/edge-fqm.yaml
+++ b/src/main/resources/swagger.api/edge-fqm.yaml
@@ -80,4 +80,3 @@ components:
           example: examples/unknownError.sample
           schema:
             $ref: "#/components/schemas/errorResponse"
-


### PR DESCRIPTION
Following the fix to ModuleDescriptor for EDGFQM-2:
The API Workflows are only triggered by changes to the API descriptions or schema. Hence this no-op to trigger the Workflows.
