### PR TITLE
EDGFQM-6 Downgrade edge-common-spring to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <!-- runtime dependencies -->
     <folio-spring-base.version>7.1.2</folio-spring-base.version>
     <folio-query-tool-metadata.version>1.0.0-SNAPSHOT</folio-query-tool-metadata.version>
-    <edge-common-spring.version>2.3.0-SNAPSHOT</edge-common-spring.version>
+    <edge-common-spring.version>2.2.0</edge-common-spring.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
 


### PR DESCRIPTION
There was a recent breaking change in the verison of edge-common-spring that we were using (2.3.0-SNAPSHOT), so this commit downgrades us to the latest tagged release (2.2.0). This is just a temporary workaround, as we'll need to deal with the breaking changes soon as part of EDGFQM-6.