### PR TITLE
EDGFQM-10: fix remaining api-lint errors

### DIFF
--- a/src/main/resources/swagger.api/edge-fqm.yaml
+++ b/src/main/resources/swagger.api/edge-fqm.yaml
@@ -13,7 +13,7 @@ paths:
       operationId: getEntityTypeSummary
       tags:
         - entityTypes
-      description: Get names for a list of entity type ids.
+      description: Get names for a list of entity type ids
       parameters:
         - $ref: '#/components/parameters/entity-type-ids'
       responses:
@@ -70,13 +70,21 @@ components:
       description: Validation errors
       content:
         application/json:
-          example: examples/validationErrorResponse.sample
+          example:
+            errors:
+              - message: Request is invalid
+                code: invalid.request
+            total_records: 1
           schema:
             $ref: "#/components/schemas/errorResponse"
     internalServerErrorResponse:
       description: When unhandled exception occurred during code execution, e.g. NullPointerException
       content:
         application/json:
-          example: examples/unknownError.sample
+          example:
+            errors:
+              - message: Unexpected error
+                code: unexpected.error
+            total_records: 1
           schema:
             $ref: "#/components/schemas/errorResponse"


### PR DESCRIPTION
## Purpose
[EDGFQM-10: fix remaining api-lint errors](https://issues.folio.org/browse/EDGFQM-10)

## Testing
- [x] App can be built with no api-lint warnings or errors (checked with -w flag)
<img width="1714" alt="Screenshot 2023-10-03 at 4 16 23 PM" src="https://github.com/folio-org/edge-fqm/assets/97990858/62e7c216-1d20-47f2-9d21-6c97fc3732cf">
