### PR TITLE
Fix build errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,11 @@
     <edge-common-spring.version>2.3.0-SNAPSHOT</edge-common-spring.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
+    <httpclient.version>4.5.14</httpclient.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
 
     <!-- test dependencies -->
-    <wiremock.version>2.35.0</wiremock.version>
+    <wiremock.version>3.2.0</wiremock.version>
     <testcontainers.version>1.17.6</testcontainers.version>
     <edge-common.version>4.4.3</edge-common.version>
     <mockwebserver.version>4.11.0</mockwebserver.version>
@@ -136,6 +138,11 @@
       <version>${mapstruct.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>
@@ -160,8 +167,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
@@ -189,6 +196,18 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Transitive dependency from folio-spring-base. Specifying newer version in order to remove vulnerabilities -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${snakeyaml.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>


### PR DESCRIPTION
## Purpose
edge-fqm is not building properly due missing/out-of-date dependencies. Add the dependencies so that the builds succeed again

## Testing 
- [x] edge-fqm can be built and deployed successfully
