### PR TITLE
EDGFQM-12: Spring Boot 3.1.5, okio-jvm 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>org.folio</groupId>
   <artifactId>edge-fqm</artifactId>
   <name>edge-fqm</name>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
   <description>Edge API for FOLIO Query Machine</description>
   <packaging>jar</packaging>
 
@@ -411,7 +411,7 @@
     <url>https://github.com/FOLIO-EIS/${project.artifactId}</url>
     <connection>scm:git:git://github.com/FOLIO-EIS/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:FOLIO-EIS/${project.artifactId}.git</developerConnection>
-    <tag>v1.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.2</version>
+    <version>3.1.5</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -47,6 +47,9 @@
 
     <!-- runtime dependencies -->
     <folio-spring-base.version>7.1.2</folio-spring-base.version>
+    <!-- fix okio-jvm Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2023-3635
+         remove okio-jvm dependency after upgrading to folio-spring-base >= 7.2.2 -->
+    <okio-jvm.version>3.4.0</okio-jvm.version>
     <folio-query-tool-metadata.version>1.0.0</folio-query-tool-metadata.version>
     <edge-common-spring.version>2.3.0</edge-common-spring.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
@@ -72,6 +75,13 @@
           <artifactId>spring-boot-starter-data-jpa</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <!-- fix okio-jvm Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2023-3635
+           remove okio-jvm dependency after upgrading to folio-spring-base >= 7.2.2 -->
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <version>${okio-jvm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
https://issues.folio.org/browse/FOLSPRINGB-130

Upgrade Spring Boot from 3.1.2 to 3.1.5. This indirectly upgrades tomcat-embed-core from 10.1.11 to 10.1.15 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2023-44487

Upgrade okio-jvm from 3.0.0 to 3.4.0 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2023-3635