### PR TITLE
EDGEFQM-16 Bump Spring Boot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.5</version>
+    <version>3.2.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -46,9 +46,9 @@
     <argLine />
 
     <!-- runtime dependencies -->
-    <folio-spring-base.version>7.2.1</folio-spring-base.version>
+    <folio-spring-base.version>8.1.0</folio-spring-base.version>
     <folio-query-tool-metadata.version>1.2.0-SNAPSHOT</folio-query-tool-metadata.version>
-    <edge-common-spring.version>2.3.0</edge-common-spring.version>
+    <edge-common-spring.version>2.3.2</edge-common-spring.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
     <httpclient.version>4.5.14</httpclient.version>
@@ -57,7 +57,7 @@
     <!-- test dependencies -->
     <wiremock.version>3.2.0</wiremock.version>
     <testcontainers.version>1.17.6</testcontainers.version>
-    <edge-common.version>4.4.3</edge-common.version>
+    <edge-common.version>4.5.2</edge-common.version>
     <mockwebserver.version>4.11.0</mockwebserver.version>
   </properties>
 
@@ -411,7 +411,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v1.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ folio:
       enabled: false
   system-user:
     username: dummy # This isn't actually used, but we get dependency injection errors from folio-spring-system-user if we don't have it
+    password: dummy # This isn't actually used, but we get dependency injection errors from folio-spring-system-user if we don't have it
   environment: dev # Overridden at runtime in production, but causes folio-spring-system-user DI errors if it's not set
 edge:
   security:


### PR DESCRIPTION
This commit bumps our Spring Boot version from 3.1.2 to 3.2.3, which is the latest stable release. This also bumps our dependency versions for folio-spring-base (7.1.2 -> 8.1.0), edge-common-spring (2.3.0 -> 2.3.2), and edge-common (4.4.3 -> 4.5.2) to their latest releases, to bring them all in alignment with the newer Spring Boot version

This also required adding a new dummy property
(folio.system-user.password) that is required for the module to start up. This property isn't used.