### PR TITLE
EDGFQM-20: Spring Boot 3.2.6, edge-common-spring 2.4.4 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.6</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -48,7 +48,7 @@
     <!-- runtime dependencies -->
     <folio-spring-base.version>8.1.0</folio-spring-base.version>
     <folio-query-tool-metadata.version>2.0.0</folio-query-tool-metadata.version>
-    <edge-common-spring.version>2.4.3</edge-common-spring.version>
+    <edge-common-spring.version>2.4.4</edge-common-spring.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
     <httpclient.version>4.5.14</httpclient.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGFQM-20

Upgrade Spring Boot from 3.2.3 to 3.2.6.

Upgrade edge-common-spring from 2.4.3 to 2.4.4.

The Spring Boot upgrade indirectly upgrades spring-web:jar from 6.1.4 to 6.1.8 fixing two open redirect vulnerabilities in UriComponentsBuilder:

* https://www.cve.org/CVERecord?id=CVE-2024-22259
* https://www.cve.org/CVERecord?id=CVE-2024-22262

The edge-common-spring upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.110.Final fixing

* https://www.cve.org/CVERecord?id=CVE-2024-29025 – form POST out-of-memory

## Purpose
Fix vulnerabilities.

## Approach
Upgrade dependencies to fixed patch version.