### PR TITLE
bump up edge-common-spring to v2.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <!-- runtime dependencies -->
     <folio-spring-base.version>8.1.0</folio-spring-base.version>
     <folio-query-tool-metadata.version>2.0.0</folio-query-tool-metadata.version>
-    <edge-common-spring.version>2.4.4</edge-common-spring.version>
+    <edge-common-spring.version>2.4.5</edge-common-spring.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
     <httpclient.version>4.5.14</httpclient.version>
@@ -60,7 +60,6 @@
     <edge-common.version>4.5.2</edge-common.version>
     <mockwebserver.version>4.11.0</mockwebserver.version>
     <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
-    <folio-tls-utils.version>1.5.0</folio-tls-utils.version>
     <jfixture.version>2.7.2</jfixture.version>
   </properties>
 
@@ -154,11 +153,6 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>folio-tls-utils</artifactId>
-      <version>${folio-tls-utils.version}</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
bump up edge-common-spring to v2.4.5: AwsParamStore to support FIPS-approved crypto modules
