### PR TITLE
[FAT-16152] [EDGFQM-25] Change Jackson serialization to match mod-fqm-manager

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,6 @@ spring:
   liquibase:
     enabled: false
   jackson:
-    default-property-inclusion: non_empty
     deserialization:
       fail-on-unknown-properties: false
       accept-single-value-as-array: true


### PR DESCRIPTION
`mod-fqm-manager` used to only include non_empty properties during Jackson serialization, however, [this was changed as part of MODFQMMGR-442](https://github.com/folio-org/mod-fqm-manager/commit/f4b54b090b90f910e506fa8421e711f5dfdd4bbd#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825d). This updates `edge-fqm` to do the same, as the difference is breaking Karate tests.