### PR TITLE
EDGFQM-28: Release 2.0.3 - fix vulns: edge-common-spring 2.4.6, folio-spring-base 8.1.2, Spring Boot 3.2.11

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-# v2.0.x
+## v2.0.3
+- Fixing vulns: edge-common-spring 2.4.6, folio-spring-base 8.1.2, Spring Boot 3.2.11 ([EDGFQM-28](https://folio-org.atlassian.net/browse/EDGFQM-28))
 
 ## v2.0.2
 -  bump up edge-common-spring to v2.4.5: AwsParamStore to support FIPS-approved crypto modules ([EDGFQM-22](https://folio-org.atlassian.net/browse/EDGFQM-22)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.11</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -46,9 +46,9 @@
     <argLine />
 
     <!-- runtime dependencies -->
-    <folio-spring-base.version>8.1.0</folio-spring-base.version>
+    <folio-spring-base.version>8.1.2</folio-spring-base.version>
     <folio-query-tool-metadata.version>2.0.0</folio-query-tool-metadata.version>
-    <edge-common-spring.version>2.4.5</edge-common-spring.version>
+    <edge-common-spring.version>2.4.6</edge-common-spring.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
     <httpclient.version>4.5.14</httpclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>org.folio</groupId>
   <artifactId>edge-fqm</artifactId>
   <name>edge-fqm</name>
-  <version>2.0.3</version>
+  <version>2.0.4-SNAPSHOT</version>
   <description>Edge API for FOLIO Query Machine</description>
   <packaging>jar</packaging>
 
@@ -423,7 +423,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v2.0.3</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>org.folio</groupId>
   <artifactId>edge-fqm</artifactId>
   <name>edge-fqm</name>
-  <version>2.0.3-SNAPSHOT</version>
+  <version>2.0.3</version>
   <description>Edge API for FOLIO Query Machine</description>
   <packaging>jar</packaging>
 
@@ -423,7 +423,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.3</tag>
   </scm>
 
 </project>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGFQM-28

## Purpose
Fix security vulnerabilities.

## Approach
Bump patch version of dependencies:

Upgrade edge-common-spring from 2.4.5 to 2.4.6.

Upgrade folio-spring-base from 8.1.0 to 8.1.2.

Upgrade Spring Boot from 3.2.3 to 3.2.11.