### PR TITLE
[MODFQMMGR-763] Remove afterId parameter from synchronous query endpoint

### DIFF
--- a/src/main/java/org/folio/fqm/edge/client/QueryClient.java
+++ b/src/main/java/org/folio/fqm/edge/client/QueryClient.java
@@ -23,7 +23,6 @@ public interface QueryClient {
   ResultsetPage runFqlQuery(@RequestParam @NotNull String query,
                             @RequestParam @NotNull UUID entityTypeId,
                             @RequestParam(required = false) List<String> fields,
-                            @RequestParam(required = false) List<String> afterId,
                             @RequestParam(required = false) Integer limit);
 
   @DeleteExchange(url = "/{queryId}")

--- a/src/main/java/org/folio/fqm/edge/controller/QueryController.java
+++ b/src/main/java/org/folio/fqm/edge/controller/QueryController.java
@@ -25,8 +25,8 @@ public class QueryController implements FqlQueryApi {
   private final QueryService queryService;
 
   @Override
-  public ResponseEntity<ResultsetPage> runFqlQuery(String query, UUID entityTypeId, List<String> fields, List<String> afterId, Integer limit) {
-    return ResponseEntity.ok(queryService.runFqlQuery(query, entityTypeId, fields, afterId, limit));
+  public ResponseEntity<ResultsetPage> runFqlQuery(String query, UUID entityTypeId, List<String> fields, Integer limit) {
+    return ResponseEntity.ok(queryService.runFqlQuery(query, entityTypeId, fields, limit));
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/edge/service/QueryService.java
+++ b/src/main/java/org/folio/fqm/edge/service/QueryService.java
@@ -20,8 +20,8 @@ public class QueryService {
 
   private final QueryClient queryClient;
 
-  public ResultsetPage runFqlQuery(@NotNull String query, @NotNull UUID entityTypeId, List<String> fields, List<String> afterId, Integer limit) {
-    return queryClient.runFqlQuery(query, entityTypeId, fields, afterId, limit);
+  public ResultsetPage runFqlQuery(@NotNull String query, @NotNull UUID entityTypeId, List<String> fields, Integer limit) {
+    return queryClient.runFqlQuery(query, entityTypeId, fields, limit);
   }
 
   public void deleteQuery(UUID queryId) {


### PR DESCRIPTION
## Purpose
[MODFQMMGFR-763](https://folio-org.atlassian.net/browse/MODFQMMGR-763): Remove afterId parameter from synchronous query endpoint
