### PR TITLE
EDGFQM-50 - Upgrade edge-common-spring in edge-fqm

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -11,3 +11,9 @@ jobs:
     # Only handle push events from the main branch or tags, to decrease PR noise
     if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit
+    with:
+      java-version: '21'
+      publish-module-descriptor: true
+      allow-snapshots-release: false
+      do-sonar-scan: true
+      do-docker: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## v4.2.0
+- Upgrade edge-common-spring from 4.0.0 to 4.0.1 to fix HTTP cookie handling ([EDGFQM-50](https://folio-org.atlassian.net/browse/EDGFQM-50))
+
+
 ## v4.1.2
 - Upgrade edge-common from 4.9.0 to 5.1.1 to fix TLS issues ([EDGFQM-49](https://folio-org.atlassian.net/browse/EDGFQM-49))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 ## v4.2.0
 - Upgrade edge-common-spring from 4.0.0 to 4.0.1 to fix HTTP cookie handling ([EDGFQM-50](https://folio-org.atlassian.net/browse/EDGFQM-50))
 
-
 ## v4.1.2
 - Upgrade edge-common from 4.9.0 to 5.1.1 to fix TLS issues ([EDGFQM-49](https://folio-org.atlassian.net/browse/EDGFQM-49))
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <!-- runtime dependencies -->
     <folio-spring-base.version>10.0.0</folio-spring-base.version>
     <folio-query-tool-metadata.version>4.0.0</folio-query-tool-metadata.version>
-    <edge-common-spring.version>4.0.0</edge-common-spring.version>
+    <edge-common-spring.version>4.0.1</edge-common-spring.version>
     <openapi-generator.version>7.20.0</openapi-generator.version>
     <mapstruct.version>1.6.3</mapstruct.version>
 


### PR DESCRIPTION
## Purpose
Upgrade version of edge-common-spring to 4.0.1 to fix HTTP cookie handling (https://folio-org.atlassian.net/browse/EDGCMNSPR-69)
